### PR TITLE
deps: bump @vitest/browser from 4.1.9 to 4.1.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -162,7 +162,7 @@
         "@typescript-eslint/eslint-plugin": "^8.62.0",
         "@typescript-eslint/parser": "^8.62.0",
         "@vitejs/plugin-react": "^6.0.2",
-        "@vitest/browser": "^4.1.9",
+        "@vitest/browser": "^4.1.10",
         "@vitest/coverage-v8": "^4.1.10",
         "cross-env": "^10.1.0",
         "dotenv": "^17.4.2",

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "@typescript-eslint/eslint-plugin": "^8.62.0",
     "@typescript-eslint/parser": "^8.62.0",
     "@vitejs/plugin-react": "^6.0.2",
-    "@vitest/browser": "^4.1.9",
+    "@vitest/browser": "^4.1.10",
     "@vitest/coverage-v8": "^4.1.10",
     "cross-env": "^10.1.0",
     "dotenv": "^17.4.2",


### PR DESCRIPTION
Replacement for #169, which Dependabot automatically closed after #167 updated the shared Vitest lockfile. This keeps the direct dependency range in package.json and package-lock.json aligned with the resolved 4.1.10 version.