### PR TITLE
fix package lock after dependency merges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17372,6 +17372,17 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/nitro/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/nitro/node_modules/rolldown": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.2.tgz",


### PR DESCRIPTION
## What changed

Adds the missing `nitro/node_modules/lru-cache@11.5.2` optional peer entry to `package-lock.json`.

## Why

After merging the dependency PRs, `npm ci` rejected the combined lockfile as out of sync. The independent Dependabot lockfile updates did not retain this nested optional peer entry when combined.

## Impact

Restores deterministic clean installs without changing any direct dependency versions or application code.

## Validation

- `npm ci --dry-run --ignore-scripts`
